### PR TITLE
ユーザ登録APIのURLを変更

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -21,8 +21,8 @@ func GetRouter() *gin.Engine {
 	}))
 
 	r.GET("/", controller.SayHello)
-	r.POST("api/login", controller.Login)
-	r.POST("api/register", controller.Register)
+	r.POST("/api/login", controller.Login)
+	r.POST("/api/users/register", controller.Register)
 
 	api := r.Group("/api", middleware.JWTAuthMiddleware())
 	{


### PR DESCRIPTION
# 概要
ユーザ登録APIのURLが「api/register」になっており、本の登録なのかユーザの登録なのか分かりづらかったので修正

# 修正点
- ユーザ登録APIのURLを「api/users/register」に変更

# 動作確認
## 手順
- [ ] PostmanのCBM/Users/ユーザ登録を開く
- [ ] URLが「http://localhost:8080/api/users/register 」になっていることを確認する
- [ ] JSONに登録していないユーザ情報を入力して送信ボタンをクリック
- [ ] HTTPメソッドが201になっており、ユーザ登録が完了しましたという内容が返ってくればOK
